### PR TITLE
Add sh_loader and minor style changes

### DIFF
--- a/aurora/gamemode/cl_init.lua
+++ b/aurora/gamemode/cl_init.lua
@@ -2,6 +2,7 @@ GM.Name = "The Aurora Framework"
 GM.Author = "Fedox"
 GM.Version = "1.0"
 
+include("libraries/sh_loader.lua")
 include("shared.lua")
 
 DeriveGamemode("sandbox")

--- a/aurora/gamemode/cl_init.lua
+++ b/aurora/gamemode/cl_init.lua
@@ -1,6 +1,6 @@
 GM.Name = "The Aurora Framework"
-GM.Author = "Fedox"
-GM.Version = "1.0"
+GM.Author = "Aurora Studios"
+GM.Version = "1.0.0"
 
 include("libraries/sh_loader.lua")
 include("shared.lua")

--- a/aurora/gamemode/init.lua
+++ b/aurora/gamemode/init.lua
@@ -2,7 +2,10 @@ GM.Name = "The Aurora Framework"
 GM.Author = "Aurora Studios"
 GM.Version = "1.0.0"
 
+AddCSLuaFile("libraries/sh_loader.lua")
 AddCSLuaFile("shared.lua")
+
+include("libraries/sh_loader.lua")
 include("shared.lua")
 
 DeriveGamemode("sandbox")

--- a/aurora/gamemode/init.lua
+++ b/aurora/gamemode/init.lua
@@ -11,7 +11,7 @@ include("shared.lua")
 DeriveGamemode("sandbox")
 DEFINE_BASECLASS("gamemode_sandbox")
 
---- Displays the gamemode banner in the console with version and author information
+--- Displays the gamemode banner in the console with version and author information.
 -- @realm shared
 -- @param[opt] color table The color to display the banner in (defaults to color_white)
 -- @return boolean True if banner was displayed successfully, false otherwise

--- a/aurora/gamemode/libraries/sh_loader.lua
+++ b/aurora/gamemode/libraries/sh_loader.lua
@@ -18,32 +18,30 @@ function aurora.includeFile(filePath)
     end
 end
 
--- Includes all files in a directory
+-- Includes all files in a directory, including subdirectories
 -- @realm shared
 -- @string directory The directory to include files from
 function aurora.includeDir(directory)
     local baseDir = "aurora/gamemode/"
 
-    for _, v in ipairs(file.Find(baseDir .. directory .. "/*", "LUA")) do
-        aurora.includeFile(baseDir .. directory .. "/" .. v)
+    local files, folders = file.Find(baseDir .. directory .. "/*", "LUA")
+
+    for _, v in ipairs(files) do
+        local fullPath = directory .. "/" .. v
+        aurora.includeFile(baseDir .. fullPath)
     end
+
+    for _, v in ipairs(folders) do
+        local fullPath = directory .. "/" .. v
+        aurora.includeDir(fullPath)
+    end
+
 end
 
 local function loadCore()
-    local coreFolder = "aurora/gamemode/core/"
-    local realms = { "server", "client", "shared" }
-
-    for _, realm in ipairs(realms) do
-        local realmDir = coreFolder .. realm .. "/"
-        local files, _ = file.Find(realmDir .. "*", "LUA")
-
-        if files then
-            for _, fileName in SortedPairs(files) do
-                local filePath = realmDir .. fileName
-                aurora.includeFile(filePath)
-            end
-        end
-    end
+    aurora.includeDir("core/server")
+    aurora.includeDir("core/client")
+    aurora.includeDir("core/shared")
 end
 
 loadCore()

--- a/aurora/gamemode/libraries/sh_loader.lua
+++ b/aurora/gamemode/libraries/sh_loader.lua
@@ -1,5 +1,8 @@
 aurora = aurora or {}
 
+-- Includes a lua file based off the prefix or parent directory.
+-- @realm shared
+-- @string filePath The file path to include
 function aurora.includeFile(filePath)
     if filePath:find("sh_") or filePath:find("/shared/") then
         if SERVER then AddCSLuaFile(filePath) end
@@ -12,6 +15,17 @@ function aurora.includeFile(filePath)
         else
             return include(filePath)
         end
+    end
+end
+
+-- Includes all files in a directory
+-- @realm shared
+-- @string directory The directory to include files from
+function aurora.includeDir(directory)
+    local baseDir = "aurora/gamemode/"
+
+    for _, v in ipairs(file.Find(baseDir .. directory .. "/*", "LUA")) do
+        aurora.includeFile(baseDir .. directory .. "/" .. v)
     end
 end
 

--- a/aurora/gamemode/libraries/sh_loader.lua
+++ b/aurora/gamemode/libraries/sh_loader.lua
@@ -18,7 +18,7 @@ function aurora.includeFile(filePath)
     end
 end
 
--- Includes all files in a directory, including subdirectories
+-- Includes all files in a directory, including subdirectories.
 -- @realm shared
 -- @string directory The directory to include files from
 function aurora.includeDir(directory)

--- a/aurora/gamemode/libraries/sh_loader.lua
+++ b/aurora/gamemode/libraries/sh_loader.lua
@@ -41,7 +41,6 @@ local function loadCore()
             for _, fileName in SortedPairs(files) do
                 local filePath = realmDir .. fileName
                 aurora.includeFile(filePath)
-                print(string.format("Loaded %s", filePath))
             end
         end
     end

--- a/aurora/gamemode/libraries/sh_loader.lua
+++ b/aurora/gamemode/libraries/sh_loader.lua
@@ -1,0 +1,36 @@
+aurora = aurora or {}
+
+function aurora.includeFile(filePath)
+    if filePath:find("sh_") or filePath:find("/shared/") then
+        if SERVER then AddCSLuaFile(filePath) end
+        return include(filePath)
+    elseif filePath:find("sv_") or filePath:find("/server/") then
+        if SERVER then return include(filePath) end
+    elseif filePath:find("cl_") or filePath:find("/client/") then
+        if SERVER then
+            AddCSLuaFile(filePath)
+        else
+            return include(filePath)
+        end
+    end
+end
+
+local function loadCore()
+    local coreFolder = "aurora/gamemode/core/"
+    local realms = { "server", "client", "shared" }
+
+    for _, realm in ipairs(realms) do
+        local realmDir = coreFolder .. realm .. "/"
+        local files, _ = file.Find(realmDir .. "*", "LUA")
+
+        if files then
+            for _, fileName in SortedPairs(files) do
+                local filePath = realmDir .. fileName
+                aurora.includeFile(filePath)
+                print(string.format("Loaded %s", filePath))
+            end
+        end
+    end
+end
+
+loadCore()

--- a/aurora/gamemode/shared.lua
+++ b/aurora/gamemode/shared.lua
@@ -1,5 +1,4 @@
---- Initializes the gamemode
+--- Initializes the gamemode.
 -- @module aurora
 -- @realm shared
 aurora = aurora or {}
-

--- a/aurora/gamemode/shared.lua
+++ b/aurora/gamemode/shared.lua
@@ -2,3 +2,4 @@
 -- @module aurora
 -- @realm shared
 aurora = aurora or {}
+

--- a/aurora/gamemode/shared.lua
+++ b/aurora/gamemode/shared.lua
@@ -2,3 +2,5 @@
 -- @module aurora
 -- @realm shared
 aurora = aurora or {}
+
+aurora.includeDir("libraries")


### PR DESCRIPTION
Adds the following include functions inside ```sh_loader.lua```:
- ```aurora.includeDir(Directory)```
- ```aurora.includeFile(filePath)```
- ```loadCore()```

```loadCore``` is only used inside the loader file, libraries are also included inside the shared file. 
 
All functions are documented, apart from the ```loadCore()``` due to it being a local function.